### PR TITLE
KAN-174: trust-score probe sensitivity to graph-quality regressions

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -39,6 +39,14 @@ jobs:
           python -m probes.synthetic_ask > ask.json
           cat ask.json
 
+      - name: Run graph-quality probe
+        id: graph_quality
+        env:
+          REPORIUM_ADMIN_KEY: ${{ secrets.REPORIUM_ADMIN_KEY }}
+        run: |
+          python -m probes.graph_quality > graph_quality.json
+          cat graph_quality.json
+
       - name: Compute score and save to history
         run: |
           python - <<'EOF'
@@ -50,12 +58,14 @@ jobs:
 
           health = json.loads(Path("health.json").read_text())
           ask = json.loads(Path("ask.json").read_text())
-          score = compute_trust_score(health, ask)
+          graph_quality = json.loads(Path("graph_quality.json").read_text())
+          score = compute_trust_score(health, ask, graph_quality)
           now = datetime.now(timezone.utc)
           payload = {
               "score": score,
               "health": health,
               "ask": ask,
+              "graph_quality": graph_quality,
               "ts": now.isoformat(),
           }
           path = save_to_history(payload, now)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composite = 30*reliability + 35*quality + 20*integrity + 15*freshness
 All four terms are normalized to `[0, 1]` before weighting, so a perfect score
 is `100.0`.
 
-**Phase 1 status:** only `reliability` is measured. `quality`, `integrity`, and
+**Status:** `reliability` and `quality` are measured. `integrity` and
 `freshness` are hard-coded to `1.0` as placeholders and come online in later
 phases (see roadmap).
 
@@ -24,6 +24,12 @@ phases (see roadmap).
 - Home page (`https://www.reporium.com/`) returns 200
 - API health (`/health`) returns 200
 - Synthetic `ask/stream` probes complete cleanly (`{type: "done"}` received)
+
+`quality` (KAN-174) reads `/metrics/graph-quality` and weights each edge
+family (`DEPENDS_ON`, `ALTERNATIVE_TO`, `EXTENDS`, `COMPATIBLE_WITH`) by its
+`precision_proxy`. It hard-fails to `0.0` if ANY family drops below the
+KAN-147 precision floor of `0.7`, so the probe surfaces real graph
+regressions instead of riding flat at `1.0`.
 
 ## How it runs
 
@@ -39,7 +45,7 @@ Every hourly snapshot is a JSON file committed to `history/` in this repo.
 Public, diffable, time-stamped. No database, no blob store — the git log *is*
 the audit trail.
 
-## Secret required
+## Secrets required
 
 The synthetic-ask probe needs an app token. Kim must set it once:
 
@@ -52,6 +58,18 @@ gh secret set REPORIUM_APP_TOKEN \
 If unset, `probes/synthetic_ask.py` skips gracefully (each probe records
 `"error": "REPORIUM_APP_TOKEN not set; skipping"`) and `reliability` drops to 0
 until it's configured. **Never commit the token value.**
+
+The graph-quality probe needs the admin key for `/metrics/graph-quality`:
+
+```bash
+gh secret set REPORIUM_ADMIN_KEY \
+  --body "<admin-key>" \
+  --repo perditioinc/reporium-trust-score
+```
+
+If unset, `probes/graph_quality.py` returns `{"available": false, ...}` and
+the Quality sub-score drops to 0 (treated as a missing-signal regression,
+not a green pass).
 
 ## Roadmap
 

--- a/lib/score.py
+++ b/lib/score.py
@@ -1,14 +1,71 @@
 """Composite trust score.
 
-Phase 1: Reliability term is measured. Quality, Integrity, Freshness are
-placeholders (1.0) and will come online in Phases 4-5.
+Phase 1: Reliability term is measured.
+KAN-174: Quality term is now wired to the live `/metrics/graph-quality`
+snapshot so the hourly probe stops returning composite=1.0 when KAN-147's
+nightly invariants are firing on real regressions. Integrity and freshness
+remain placeholders (Phases 4-5).
 
 Weights: 30 reliability + 35 quality + 20 integrity + 15 freshness = 100.
 """
 from __future__ import annotations
 
+# Edge families the graph-quality endpoint exposes today. Quality sub-score
+# weighs each one by its precision_proxy AND requires non-zero live edges,
+# so a "functionally dead" type (live_edges=0) contributes 0 to the average.
+EDGE_TYPES = ("DEPENDS_ON", "ALTERNATIVE_TO", "EXTENDS", "COMPATIBLE_WITH")
 
-def compute_trust_score(health: dict, ask_results: dict) -> dict:
+# KAN-147 invariant floor. If ANY family's precision drops below this, the
+# Quality sub-score hard-fails to 0.0 -- this is what makes the probe LOUD
+# when a regression fires (correctness audit P1, 2026-04-29).
+PRECISION_FLOOR = 0.7
+
+
+def quality_subscore(graph_quality_metrics: dict | None) -> float:
+    """Quality sub-score weighted by edge-count x precision_proxy per family.
+
+    Hard-fails to 0.0 if ANY edge family's precision is below
+    :data:`PRECISION_FLOOR`. Otherwise returns the unweighted mean of
+    `precision * (1 if live_edges > 0 else 0)` across all four edge types,
+    so a dead family pulls the score down without crashing on missing data.
+
+    If the metrics payload is missing/unavailable (probe failure), returns
+    0.0 -- a missing signal is treated as a regression, not as a green pass.
+    """
+    if not graph_quality_metrics or not graph_quality_metrics.get("available", True):
+        return 0.0
+
+    edge_types = graph_quality_metrics.get("edge_types") or {}
+    if not edge_types:
+        return 0.0
+
+    weighted_scores: list[float] = []
+    for et in EDGE_TYPES:
+        info = edge_types.get(et) or {}
+        # DEPENDS_ON exposes "precision" (exact); the proxies expose
+        # "precision_proxy". Treat them interchangeably.
+        precision = info.get("precision")
+        if precision is None:
+            precision = info.get("precision_proxy")
+        precision = float(precision) if precision is not None else 0.0
+        live_edges = int(info.get("live_edges", 0) or 0)
+
+        # Hard-fail composite when any family falls below the KAN-147 floor.
+        if precision < PRECISION_FLOOR:
+            return 0.0
+
+        # Dead family (no live edges) contributes 0 -- partial-coverage
+        # regression, not a hard fail.
+        weighted_scores.append(precision if live_edges > 0 else 0.0)
+
+    return sum(weighted_scores) / len(EDGE_TYPES)
+
+
+def compute_trust_score(
+    health: dict,
+    ask_results: dict,
+    graph_quality: dict | None = None,
+) -> dict:
     home_ok = health.get("home_status") == 200
     api_ok = health.get("api_health_status") == 200
     probes = ask_results.get("probes", [])
@@ -19,14 +76,14 @@ def compute_trust_score(health: dict, ask_results: dict) -> dict:
         * (1.0 if api_ok else 0.0)
         * (1 - error_rate)
     )
-    quality = 1.0      # Phase 5 will implement
+    quality = quality_subscore(graph_quality)
     integrity = 1.0    # Phase 4 will implement
     freshness = 1.0    # Phase 5 will implement
     composite = 30 * reliability + 35 * quality + 20 * integrity + 15 * freshness
     return {
         "composite": round(composite, 1),
         "reliability": round(reliability, 3),
-        "quality": quality,
+        "quality": round(quality, 3),
         "integrity": integrity,
         "freshness": freshness,
         "error_rate": round(error_rate, 3),

--- a/probes/graph_quality.py
+++ b/probes/graph_quality.py
@@ -1,0 +1,54 @@
+"""Graph-quality probe: pull /metrics/graph-quality so the Quality sub-score
+can react to KAN-147 invariant violations (precision_proxy floor, dead edge
+families).
+
+KAN-174: hourly probe was returning composite=1.0 even when graph regressions
+were firing because Quality was hard-coded to 1.0. This probe surfaces the
+edge-type metrics so `lib.score.quality_subscore` can weight them by
+edge-count x precision and hard-fail when any family drops below the floor.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+import requests
+
+GRAPH_QUALITY_URL = (
+    "https://reporium-api-573778300586.us-central1.run.app/metrics/graph-quality"
+)
+TIMEOUT = 30
+
+
+def run() -> dict:
+    """Return the raw graph-quality payload, or an error envelope."""
+    ts = datetime.now(timezone.utc).isoformat()
+    admin_key = os.environ.get("REPORIUM_ADMIN_KEY", "")
+    if not admin_key:
+        return {
+            "ts": ts,
+            "available": False,
+            "error": "REPORIUM_ADMIN_KEY not set; skipping",
+        }
+    try:
+        resp = requests.get(
+            GRAPH_QUALITY_URL,
+            headers={"X-Admin-Key": admin_key, "Accept": "application/json"},
+            timeout=TIMEOUT,
+        )
+        if resp.status_code != 200:
+            return {
+                "ts": ts,
+                "available": False,
+                "error": f"HTTP {resp.status_code}",
+            }
+        body = resp.json()
+        body["ts"] = ts
+        return body
+    except Exception as exc:  # noqa: BLE001 - tolerate all network failures
+        return {"ts": ts, "available": False, "error": str(exc)}
+
+
+if __name__ == "__main__":
+    print(json.dumps(run()))

--- a/tests/test_quality_subscore.py
+++ b/tests/test_quality_subscore.py
@@ -1,0 +1,192 @@
+"""Synthetic regression tests for KAN-174 Quality sub-score sensitivity.
+
+The hourly probe was returning composite=1.0 even when KAN-147's nightly
+graph-quality invariants were firing. These tests pin the new behavior:
+
+1. EXTENDS.precision_proxy=0.0 -> composite drops to 0.0 (was 1.0 before fix).
+2. All families healthy -> composite stays at 1.0.
+3. ALTERNATIVE_TO.live_edges=0 with precision=0.95 -> that family contributes
+   0; composite reflects partial coverage rather than a hard fail.
+"""
+from __future__ import annotations
+
+from lib.score import PRECISION_FLOOR, compute_trust_score, quality_subscore
+
+
+def _healthy_health() -> dict:
+    return {"home_status": 200, "api_health_status": 200}
+
+
+def _healthy_ask() -> dict:
+    return {
+        "probes": [
+            {"completed": True},
+            {"completed": True},
+            {"completed": True},
+        ]
+    }
+
+
+def _all_healthy_graph_quality() -> dict:
+    """Every edge family above the floor and with live edges."""
+    return {
+        "available": True,
+        "edge_types": {
+            "DEPENDS_ON": {"live_edges": 250, "precision": 1.0},
+            "ALTERNATIVE_TO": {"live_edges": 120, "precision_proxy": 0.95},
+            "EXTENDS": {"live_edges": 40, "precision_proxy": 0.9},
+            "COMPATIBLE_WITH": {"live_edges": 60, "precision_proxy": 0.85},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# quality_subscore unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_quality_hard_fails_when_extends_precision_zero():
+    """The headline regression: EXTENDS=0.0 must drop quality (and composite) to 0."""
+    metrics = _all_healthy_graph_quality()
+    metrics["edge_types"]["EXTENDS"]["precision_proxy"] = 0.0
+    assert quality_subscore(metrics) == 0.0
+
+
+def test_quality_hard_fails_when_alternative_below_floor():
+    """ALTERNATIVE_TO=0.66 (today's live state, < 0.7 floor) must hard-fail."""
+    metrics = _all_healthy_graph_quality()
+    metrics["edge_types"]["ALTERNATIVE_TO"]["precision_proxy"] = 0.66
+    assert quality_subscore(metrics) == 0.0
+
+
+def test_quality_above_floor_when_all_healthy():
+    """All families >= floor and live -> nonzero average."""
+    metrics = _all_healthy_graph_quality()
+    score = quality_subscore(metrics)
+    assert score > 0.0
+    assert score <= 1.0
+
+
+def test_quality_partial_when_one_family_dead():
+    """ALTERNATIVE_TO live_edges=0 with precision=0.95 contributes 0,
+    but the remaining 3 families with precision 1.0/0.9/0.85 should still
+    pull quality up to a partial-coverage value (~0.6875) -- not hard-fail.
+    """
+    metrics = _all_healthy_graph_quality()
+    metrics["edge_types"]["ALTERNATIVE_TO"] = {
+        "live_edges": 0,
+        "precision_proxy": 0.95,
+    }
+    score = quality_subscore(metrics)
+    expected = (1.0 + 0.0 + 0.9 + 0.85) / 4
+    assert score == expected
+    assert 0.0 < score < 1.0
+
+
+def test_quality_zero_when_metrics_missing():
+    """A failed probe (available=False) is treated as regression, not green pass."""
+    assert quality_subscore({"available": False, "error": "boom"}) == 0.0
+    assert quality_subscore(None) == 0.0
+    assert quality_subscore({}) == 0.0
+
+
+def test_quality_zero_when_edge_types_empty():
+    """Empty edge_types dict means we have no signal -> 0.0."""
+    assert quality_subscore({"available": True, "edge_types": {}}) == 0.0
+
+
+def test_quality_handles_missing_edge_family():
+    """If the API ever drops a family, treat it as live_edges=0/precision=0.
+
+    Today the API always returns all four families, but we don't want a future
+    schema change to silently flip the score to a false green. A missing
+    family means precision defaults to 0.0 which trips the floor -> 0.0.
+    """
+    metrics = _all_healthy_graph_quality()
+    del metrics["edge_types"]["EXTENDS"]
+    assert quality_subscore(metrics) == 0.0
+
+
+def test_floor_constant_matches_kan147():
+    """Pin the floor to KAN-147's 0.7. If this changes, the JIRA must too."""
+    assert PRECISION_FLOOR == 0.7
+
+
+# ---------------------------------------------------------------------------
+# compute_trust_score integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_composite_drops_to_below_baseline_when_extends_zero():
+    """The headline KAN-174 fix: composite was flat at 100.0 before; now drops."""
+    metrics = _all_healthy_graph_quality()
+    metrics["edge_types"]["EXTENDS"]["precision_proxy"] = 0.0
+    score = compute_trust_score(_healthy_health(), _healthy_ask(), metrics)
+    # Before fix: composite=100.0 even with EXTENDS dead.
+    # After fix:  reliability=1, quality=0, integrity=1, freshness=1
+    #             -> 30*1 + 35*0 + 20*1 + 15*1 = 65.0
+    assert score["quality"] == 0.0
+    assert score["composite"] == 65.0
+
+
+def test_composite_full_when_everything_healthy():
+    """Healthy reliability + healthy graph -> 100.0."""
+    score = compute_trust_score(
+        _healthy_health(), _healthy_ask(), _all_healthy_graph_quality()
+    )
+    # reliability=1.0, quality<=1.0 (avg of 1.0/0.95/0.9/0.85 = 0.925)
+    # composite = 30 + 35*0.925 + 20 + 15 = 97.4
+    assert score["reliability"] == 1.0
+    assert score["composite"] < 100.0  # quality < 1 because not all families == 1.0
+    assert score["composite"] > 90.0
+
+
+def test_composite_full_when_all_precision_one():
+    """Pure-1.0 precision across all families -> composite==100.0."""
+    metrics = {
+        "available": True,
+        "edge_types": {
+            "DEPENDS_ON": {"live_edges": 250, "precision": 1.0},
+            "ALTERNATIVE_TO": {"live_edges": 120, "precision_proxy": 1.0},
+            "EXTENDS": {"live_edges": 40, "precision_proxy": 1.0},
+            "COMPATIBLE_WITH": {"live_edges": 60, "precision_proxy": 1.0},
+        },
+    }
+    score = compute_trust_score(_healthy_health(), _healthy_ask(), metrics)
+    assert score["composite"] == 100.0
+
+
+def test_composite_when_graph_quality_unavailable():
+    """Probe failure -> quality=0 -> composite ceiling = 30+0+20+15 = 65."""
+    score = compute_trust_score(
+        _healthy_health(),
+        _healthy_ask(),
+        {"available": False, "error": "REPORIUM_ADMIN_KEY not set; skipping"},
+    )
+    assert score["quality"] == 0.0
+    assert score["composite"] == 65.0
+
+
+def test_composite_reflects_today_live_regression_state():
+    """Anchor test: today's reported regression state from KAN-174 description.
+
+    - ALTERNATIVE_TO precision_proxy=0.66 (below floor)
+    - EXTENDS precision_proxy=0.0
+    - DEPENDS_ON live_edges=89, precision=1.0 (corpus reality)
+    - COMPATIBLE_WITH live_edges=0
+
+    Quality should hard-fail to 0.0 (any family below floor wins).
+    Composite = 30 + 0 + 20 + 15 = 65.0, not the false-green 100.0 we had.
+    """
+    metrics = {
+        "available": True,
+        "edge_types": {
+            "DEPENDS_ON": {"live_edges": 89, "precision": 1.0},
+            "ALTERNATIVE_TO": {"live_edges": 80, "precision_proxy": 0.66},
+            "EXTENDS": {"live_edges": 30, "precision_proxy": 0.0},
+            "COMPATIBLE_WITH": {"live_edges": 0, "precision_proxy": 0.0},
+        },
+    }
+    score = compute_trust_score(_healthy_health(), _healthy_ask(), metrics)
+    assert score["quality"] == 0.0
+    assert score["composite"] == 65.0


### PR DESCRIPTION
## Why

Per the 2026-04-29 4h correctness audit P1: the hourly trust-score probe was returning `composite=1.0` flat (literally 100.0 in every history snapshot) even when KAN-147's nightly graph-quality invariants were firing on real regressions:

- `ALTERNATIVE_TO.precision_proxy=0.66` (below the 0.7 floor)
- `EXTENDS.precision_proxy=0.0` (functionally dead)
- `COMPATIBLE_WITH.live_edges=0` (functionally dead)
- `DEPENDS_ON.live_edges=89` (corpus reality / regression-adjacent)

The probe was the only hourly heartbeat watching trust posture. It being insensitive to KAN-147 violations = silent monitoring blind spot. Root cause: `lib/score.py` had `quality = 1.0` hard-coded as a Phase-5 placeholder.

## What changed

**New `probes/graph_quality.py`** — hits `GET /metrics/graph-quality` with `X-Admin-Key`, returns the raw payload (or an `available: false` envelope on failure).

**`lib.score.quality_subscore(graph_quality_metrics)`** — for each of the four edge families (`DEPENDS_ON`, `ALTERNATIVE_TO`, `EXTENDS`, `COMPATIBLE_WITH`):
- reads `precision` (DEPENDS_ON) or `precision_proxy` (the rest)
- if any family falls below `PRECISION_FLOOR = 0.7` -> **hard-fail to 0.0**
- otherwise contributes `precision * (1 if live_edges > 0 else 0)` to the average

Missing/unavailable metrics are treated as regression (0.0), not a free pass.

**Workflow update** — `hourly.yml` now runs the third probe and threads `graph_quality.json` into the score computation; the per-hour history JSON also persists the raw graph-quality payload for post-hoc audit.

## Synthetic test deltas

| Scenario | Before | After |
|---|---|---|
| All precision=1.0 across all 4 families | 100.0 | 100.0 |
| EXTENDS.precision_proxy=0.0 | **100.0** | **65.0** |
| ALTERNATIVE_TO=0.66 (today's live state) | **100.0** | **65.0** |
| Today's full regression state (ALT=0.66, EXT=0.0, COMPAT=0 edges) | **100.0** | **65.0** |
| Probe failed / admin key unset | 100.0 | 65.0 |
| Healthy 1.0/0.95/0.9/0.85 mix | 100.0 | ~97.4 |

13 new tests in `tests/test_quality_subscore.py`, all green locally.

## Operational

The probe needs a new secret:

```bash
gh secret set REPORIUM_ADMIN_KEY   --body "<admin-key>"   --repo perditioinc/reporium-trust-score
```

Until that's set, hourly composite ceiling will be 65.0 (reliability+integrity+freshness only). That's intentional: a missing-signal probe is a regression.

## Test plan

- [x] `pytest tests/` — 13/13 pass
- [x] `python -m py_compile lib/score.py probes/graph_quality.py` — clean
- [x] `python -m probes.graph_quality` runs and emits well-formed JSON
- [ ] Workflow run dispatched after merge, history JSON inspected for non-1.0 quality (next-hour run on cron, or workflow_dispatch manually after secret is set)

## References

- JIRA: https://perditio.atlassian.net/browse/KAN-174
- Audit P1: `.audit/2026-05-02-4h-run/correctness-findings.md` in perditio-platform