### PR TITLE
Add local OSS dev substrate ($0, additive, local-only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Root passthrough to the local OSS dev substrate (see local/).
+# $0 / OSS / ADDITIVE / local only. Never touches production cloud.
+
+.PHONY: up down seed smoke logs ps clean local-help
+
+up:
+	$(MAKE) -C local up
+
+down:
+	$(MAKE) -C local down
+
+seed:
+	$(MAKE) -C local seed
+
+smoke:
+	$(MAKE) -C local smoke
+
+logs:
+	$(MAKE) -C local logs
+
+ps:
+	$(MAKE) -C local ps
+
+clean:
+	$(MAKE) -C local clean
+
+local-help:
+	$(MAKE) -C local help

--- a/local/.env.example
+++ b/local/.env.example
@@ -1,0 +1,21 @@
+# Local OSS substrate env for reporium-trust-score.
+#
+# Copy to .env (gitignored) or `export` these before running the probes /
+# smoke test against the local stub. These override the production defaults
+# baked into probes/*.py so NO cloud endpoint is touched.
+
+# Point every probe's API calls at the local contract stub.
+REPORIUM_API_BASE=http://localhost:8080
+
+# Home-page reliability probe target -> local stub root.
+REPORIUM_HOME_URL=http://localhost:8080/
+
+# The stub accepts any non-empty token / admin key (it does not validate the
+# value, only that a header is present). Real secrets are NEVER needed locally.
+REPORIUM_APP_TOKEN=local-dev-token
+REPORIUM_ADMIN_KEY=local-dev-admin-key
+
+# Skip the synthetic-ask inter-query rate-limit sleep for a fast smoke run.
+# (The probe sleeps 15s between live queries to be polite to production; the
+# local stub needs no such courtesy.)
+REPORIUM_ASK_SLEEP_S=0

--- a/local/Makefile
+++ b/local/Makefile
@@ -1,0 +1,45 @@
+# Local OSS dev substrate for reporium-trust-score.
+# $0 / OSS / ADDITIVE / local only. Never touches production cloud.
+
+COMPOSE ?= docker compose
+PY      ?= python
+
+.PHONY: help up down seed smoke logs ps clean
+
+help:
+	@echo "Reporium trust-score local substrate targets:"
+	@echo "  make up     - build + start stub + postgres (waits for healthy)"
+	@echo "  make seed   - (re)apply the graph-quality seed into postgres"
+	@echo "  make smoke  - run probes against the local stub + compute a score"
+	@echo "  make down   - stop and remove containers + volumes (-v)"
+	@echo "  make logs   - tail substrate logs"
+	@echo "  make ps     - show substrate container status"
+
+up:
+	$(COMPOSE) up -d --build --wait
+
+down:
+	$(COMPOSE) down -v
+
+# The seed auto-runs on first DB init via docker-entrypoint-initdb.d. This
+# target re-applies it on demand (e.g. after editing seed/graph_quality.sql)
+# without recreating the volume.
+seed:
+	$(COMPOSE) exec -T db psql -U reporium -d reporium < seed/graph_quality.sql
+
+smoke:
+	REPORIUM_API_BASE=http://localhost:8080 \
+	REPORIUM_HOME_URL=http://localhost:8080/ \
+	REPORIUM_APP_TOKEN=local-dev-token \
+	REPORIUM_ADMIN_KEY=local-dev-admin-key \
+	REPORIUM_ASK_SLEEP_S=0 \
+	$(PY) smoke.py
+
+logs:
+	$(COMPOSE) logs --tail=100
+
+ps:
+	$(COMPOSE) ps
+
+clean: down
+	@echo "substrate torn down"

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,68 @@
+# Local OSS dev substrate
+
+A $0, fully self-hosted stand-in for every Reporium cloud dependency the
+hourly trust probes consume, so you can exercise the trust-score computation
+path end to end with no cloud, no secrets, and no paid model.
+
+This directory is **additive and local only**. It never points at production,
+and nothing here runs in CI. The production probes keep their live URLs as
+defaults; the substrate works by setting environment overrides.
+
+## What the trust score depends on (and the OSS substitute)
+
+| Production dependency | Consumed by | OSS substitute here |
+| --- | --- | --- |
+| `https://www.reporium.com/` home page (expects 200) | `probes/health.py` | `stub` `/` returns 200 HTML |
+| Cloud Run `reporium-api` `/health` (expects 200) | `probes/health.py` | `stub` `/health` returns 200 JSON |
+| `reporium-api` `/intelligence/ask/stream` SSE, LLM-backed, `X-App-Token` auth | `probes/synthetic_ask.py` | `stub` emits a deterministic canned `sources` -> `token` -> `done` stream (no paid model) |
+| `reporium-api` `/metrics/graph-quality` JSON, Postgres-backed, `X-Admin-Key` auth | `probes/graph_quality.py` | `stub` reads edge-family metrics **live from a local Postgres** seeded from `seed/graph_quality.sql`, shaping the same `source: "postgres_live"` contract |
+
+The datastore behind graph-quality is a real Postgres container (`postgres:16-alpine`),
+so the most data-shaped part of the score is exercised against an actual SQL
+query, not a hard-coded blob. The remaining endpoints (home, health, ask) are
+deterministic stubs.
+
+## How the probes are pointed locally
+
+The three probes default to the live production URLs (unchanged behavior). The
+only wiring added is environment-variable overrides:
+
+- `REPORIUM_API_BASE` -> base URL for `/health`, `/intelligence/ask/stream`,
+  `/metrics/graph-quality`
+- `REPORIUM_HOME_URL` -> home-page reliability target
+- `REPORIUM_ASK_SLEEP_S` -> inter-query courtesy sleep (default 15s; set 0 locally)
+
+`REPORIUM_APP_TOKEN` / `REPORIUM_ADMIN_KEY` already existed; the stub accepts
+any non-empty value (it checks only that a header is present), so **no real
+secret is ever needed locally**.
+
+See `.env.example` for the full set.
+
+## Quick start
+
+```bash
+# from the repo root
+make up      # build + start stub + postgres, wait until healthy
+make smoke   # run the three probes against the stub + compute a trust score
+make down    # stop and remove containers + volumes
+```
+
+Or directly inside `local/`:
+
+```bash
+docker compose up -d --build --wait
+python smoke.py
+docker compose down -v
+```
+
+`smoke.py` asserts a healthy substrate yields `reliability == 1.0`,
+`quality > 0`, `0 < composite <= 100`, and that graph-quality came back
+`available` with `source: "postgres_live"`. It writes its snapshot to a temp
+dir, so it never mutates the tracked `history/` tree.
+
+## Tuning the score for testing
+
+Edit `seed/graph_quality.sql` to drive regressions through the same code path
+the production probe uses. For example, drop `EXTENDS.precision_proxy` below
+`0.7` and re-run `make seed && make smoke` to watch the Quality sub-score
+hard-fail to 0 (and the composite fall to 65), exactly as KAN-174 intends.

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,44 @@
+# Local OSS dev substrate for reporium-trust-score.
+#
+# Brings up free, self-hosted substitutes for every Reporium cloud dependency
+# the hourly trust probes consume, so the trust-score computation path can be
+# exercised end to end with no cloud, no secrets, and no paid model.
+#
+# Cloud -> OSS substitution map:
+#   Postgres-backed /metrics/graph-quality  -> `db` (postgres:16-alpine) + seed
+#   Cloud Run reporium-api + home + ask LLM -> `stub` (stdlib contract server)
+#
+# $0 / OSS only. ADDITIVE and local only -- never points at production.
+
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: reporium
+      POSTGRES_PASSWORD: reporium
+      POSTGRES_DB: reporium
+    # Seed runs once on first init of an empty data dir.
+    volumes:
+      - ./seed:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U reporium -d reporium"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  stub:
+    build:
+      context: ./stub
+    environment:
+      STUB_PORT: "8080"
+      DATABASE_URL: "postgresql://reporium:reporium@db:5432/reporium"
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/health')\""]
+      interval: 3s
+      timeout: 3s
+      retries: 20

--- a/local/seed/graph_quality.sql
+++ b/local/seed/graph_quality.sql
@@ -1,0 +1,31 @@
+-- Local OSS seed for the graph-quality metrics the trust-score Quality
+-- sub-score reads. This stands in for the production Postgres that backs
+-- /metrics/graph-quality (source: "postgres_live").
+--
+-- Each row is one edge family. The stub (local/stub/app.py) SELECTs these
+-- rows and shapes them into the /metrics/graph-quality contract. Values are
+-- chosen so every family is above the KAN-147 precision floor (0.7) and has
+-- live edges, yielding a healthy, nonzero Quality sub-score through
+-- lib/score.py:quality_subscore.
+
+CREATE TABLE IF NOT EXISTS graph_quality_edge_types (
+    edge_type           TEXT PRIMARY KEY,
+    live_edges          INTEGER NOT NULL DEFAULT 0,
+    precision_proxy     DOUBLE PRECISION,
+    recall_proxy        DOUBLE PRECISION,
+    eligible_repos      INTEGER NOT NULL DEFAULT 0,
+    observed_repos      INTEGER NOT NULL DEFAULT 0,
+    invalid_live_edges  INTEGER NOT NULL DEFAULT 0
+);
+
+TRUNCATE graph_quality_edge_types;
+
+-- DEPENDS_ON: exact precision/recall in production. precision_proxy column
+-- carries the exact precision here; the stub maps it to "precision".
+INSERT INTO graph_quality_edge_types
+    (edge_type, live_edges, precision_proxy, recall_proxy, eligible_repos, observed_repos, invalid_live_edges)
+VALUES
+    ('DEPENDS_ON',      250, 1.00, 1.00,  250,  250,    0),
+    ('ALTERNATIVE_TO',  120, 0.95, 1.00, 1912, 1912, 1335),
+    ('EXTENDS',          40, 0.90, 0.50, 1921,  525,    0),
+    ('COMPATIBLE_WITH',  60, 0.85, 0.40,  300,  300,    0);

--- a/local/smoke.py
+++ b/local/smoke.py
@@ -1,0 +1,87 @@
+"""Local OSS smoke test for the trust-score computation path.
+
+Assumes the local substrate (`make -C local up` / docker compose up) is
+already running and reachable at REPORIUM_API_BASE. It:
+
+  1. Runs all three probes (health, synthetic_ask, graph_quality) against the
+     local stub -- the same code paths the hourly Action runs in production.
+  2. Feeds the probe outputs into lib.score.compute_trust_score -- the real
+     composite formula.
+  3. Asserts the result is sane for a healthy local substrate:
+       - reliability == 1.0   (home 200, api 200, all ask probes completed)
+       - quality      > 0.0    (graph-quality read from local Postgres, all
+                                families above the KAN-147 floor)
+       - 0 < composite <= 100
+  4. Prints the snapshot and a single PASS / FAIL line.
+
+Snapshot is written to a temp dir, NOT the repo history/, so the smoke test
+never mutates tracked data.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make the repo root importable (parent of local/).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Ensure the probes aim at the local stub even if the caller forgot to export.
+os.environ.setdefault("REPORIUM_API_BASE", "http://localhost:8080")
+os.environ.setdefault("REPORIUM_HOME_URL", "http://localhost:8080/")
+os.environ.setdefault("REPORIUM_APP_TOKEN", "local-dev-token")
+os.environ.setdefault("REPORIUM_ADMIN_KEY", "local-dev-admin-key")
+os.environ.setdefault("REPORIUM_ASK_SLEEP_S", "0")
+
+from lib.score import compute_trust_score  # noqa: E402
+from probes import graph_quality, health, synthetic_ask  # noqa: E402
+
+
+def main() -> int:
+    print(f"[smoke] probing local substrate at {os.environ['REPORIUM_API_BASE']}")
+    health_out = health.run()
+    ask_out = synthetic_ask.run()
+    gq_out = graph_quality.run()
+
+    score = compute_trust_score(health_out, ask_out, gq_out)
+    now = datetime.now(timezone.utc)
+    payload = {
+        "score": score,
+        "health": health_out,
+        "ask": ask_out,
+        "graph_quality": gq_out,
+        "ts": now.isoformat(),
+    }
+
+    # Write the snapshot to a temp dir to prove the storage path works without
+    # polluting the tracked history/ tree.
+    with tempfile.TemporaryDirectory() as td:
+        snap = Path(td) / "smoke_snapshot.json"
+        snap.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        print(f"[smoke] wrote snapshot to {snap}")
+
+    print("[smoke] score = " + json.dumps(score, indent=2, sort_keys=True))
+
+    checks = {
+        "reliability == 1.0": score["reliability"] == 1.0,
+        "quality > 0.0": score["quality"] > 0.0,
+        "0 < composite <= 100": 0.0 < score["composite"] <= 100.0,
+        "graph-quality available": bool(gq_out.get("available")),
+        "graph-quality source is postgres_live": gq_out.get("source") == "postgres_live",
+    }
+    for name, ok in checks.items():
+        print(f"[smoke] check: {name} -> {'ok' if ok else 'FAIL'}")
+
+    if all(checks.values()):
+        print(f"[smoke] PASS composite={score['composite']}")
+        return 0
+    print("[smoke] FAIL one or more checks did not hold")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/local/stub/Dockerfile
+++ b/local/stub/Dockerfile
@@ -1,0 +1,15 @@
+# Local OSS contract stub for the Reporium trust-score probes.
+# Stdlib HTTP server + psycopg2 for reading the local Postgres seed.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Only dependency: psycopg2 to read the local Postgres graph-quality seed.
+# The HTTP server itself is pure stdlib. $0/OSS.
+RUN pip install --no-cache-dir psycopg2-binary==2.9.9
+
+COPY app.py /app/app.py
+
+EXPOSE 8080
+
+CMD ["python", "-u", "/app/app.py"]

--- a/local/stub/app.py
+++ b/local/stub/app.py
@@ -1,0 +1,203 @@
+"""Local OSS contract stub for the Reporium trust-score probes.
+
+This is a $0, dependency-light stand-in for the live Reporium cloud surface
+that the hourly trust probes consume. It serves the exact contracts the three
+probes read, so the trust-score computation path can be exercised end to end
+with no cloud, no secrets, and no paid model.
+
+Endpoints served (mirroring the production contract the probes expect):
+
+  GET  /                          -> 200 text/html  (home-page reliability probe)
+  GET  /health                    -> 200 application/json (API health probe)
+  POST /intelligence/ask/stream   -> 200 text/event-stream SSE: emits
+                                     `sources`, `token`, then `done` -- the
+                                     synthetic-ask probe records `completed`
+                                     when it sees `{type: "done"}`.
+                                     Requires header X-App-Token (any value).
+  GET  /metrics/graph-quality     -> 200 application/json edge-family metrics,
+                                     read LIVE from the local Postgres so the
+                                     payload mirrors production's
+                                     `source: "postgres_live"`. Requires
+                                     header X-Admin-Key (any value).
+
+Cloud -> OSS substitution map:
+  Cloud Run reporium-api          -> this stdlib http.server stub
+  reporium.com home page          -> stub `/`
+  Vertex/LLM-backed ask/stream    -> deterministic canned SSE (no paid model)
+  Postgres-backed graph-quality   -> local Postgres container (real psql query)
+
+Only the Python stdlib is used for the HTTP server. The single non-stdlib
+dependency is `psycopg2-binary` for reading the local Postgres; if it is
+absent or the database is unreachable the stub falls back to a static payload
+so the smoke test still proves the compute path (and logs that it did so).
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+HOST = "0.0.0.0"
+PORT = int(os.environ.get("STUB_PORT", "8080"))
+
+# Canned answers for the synthetic-ask canary queries. Deterministic, no model.
+_CANNED_TOKENS = ["This ", "is ", "a ", "local ", "stub ", "answer."]
+
+
+def _pg_graph_quality() -> dict | None:
+    """Read edge-family metrics from the local Postgres. Returns a payload
+    dict shaped like production's /metrics/graph-quality, or None on failure."""
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        return None
+    try:
+        import psycopg2  # type: ignore
+    except Exception:
+        return None
+    try:
+        conn = psycopg2.connect(dsn, connect_timeout=5)
+    except Exception:
+        return None
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT edge_type, live_edges, precision_proxy, recall_proxy, "
+                "eligible_repos, observed_repos, invalid_live_edges "
+                "FROM graph_quality_edge_types ORDER BY edge_type"
+            )
+            rows = cur.fetchall()
+        edge_types: dict[str, dict] = {}
+        total_edges = 0
+        for (et, live, prec, recall, elig, obs, invalid) in rows:
+            total_edges += int(live or 0)
+            if et == "DEPENDS_ON":
+                # DEPENDS_ON exposes exact precision/recall in production.
+                edge_types[et] = {
+                    "live_edges": int(live or 0),
+                    "precision": float(prec) if prec is not None else None,
+                    "recall": float(recall) if recall is not None else None,
+                }
+            else:
+                edge_types[et] = {
+                    "live_edges": int(live or 0),
+                    "eligible_repos": int(elig or 0),
+                    "observed_repos": int(obs or 0),
+                    "invalid_live_edges": int(invalid or 0),
+                    "precision_proxy": float(prec) if prec is not None else None,
+                    "recall_proxy": float(recall) if recall is not None else None,
+                }
+        return {
+            "available": True,
+            "source": "postgres_live",
+            "edge_types": edge_types,
+            "summary": {
+                "edge_types_present": sorted(edge_types.keys()),
+                "total_edges": total_edges,
+            },
+            "notes": [
+                "Local OSS stub: edge-family metrics read live from the local "
+                "Postgres seed (see local/seed/graph_quality.sql).",
+            ],
+        }
+    except Exception:
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+# Static fallback if Postgres is unavailable. Shaped exactly like the live
+# contract; all four families above the KAN-147 floor so the compute path
+# yields a healthy, nonzero Quality sub-score.
+_STATIC_GRAPH_QUALITY = {
+    "available": True,
+    "source": "static_fallback",
+    "edge_types": {
+        "DEPENDS_ON": {"live_edges": 250, "precision": 1.0, "recall": 1.0},
+        "ALTERNATIVE_TO": {"live_edges": 120, "precision_proxy": 0.95, "recall_proxy": 1.0},
+        "EXTENDS": {"live_edges": 40, "precision_proxy": 0.9, "recall_proxy": 0.5},
+        "COMPATIBLE_WITH": {"live_edges": 60, "precision_proxy": 0.85, "recall_proxy": 0.4},
+    },
+    "summary": {
+        "edge_types_present": ["ALTERNATIVE_TO", "COMPATIBLE_WITH", "DEPENDS_ON", "EXTENDS"],
+        "total_edges": 470,
+    },
+    "notes": ["Local OSS stub: Postgres unavailable; serving static fallback payload."],
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "ReporiumLocalStub/1.0"
+
+    def _send_json(self, code: int, body: dict) -> None:
+        data = json.dumps(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt, *args):  # quieter logs
+        print("[stub] " + (fmt % args))
+
+    def do_GET(self):
+        if self.path == "/" or self.path.startswith("/index"):
+            body = b"<!doctype html><html><body><h1>Reporium (local stub)</h1></body></html>"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if self.path == "/health":
+            self._send_json(200, {"status": "ok", "service": "reporium-local-stub"})
+            return
+        if self.path.startswith("/metrics/graph-quality"):
+            if not self.headers.get("X-Admin-Key"):
+                self._send_json(401, {"available": False, "error": "missing X-Admin-Key"})
+                return
+            payload = _pg_graph_quality() or dict(_STATIC_GRAPH_QUALITY)
+            self._send_json(200, payload)
+            return
+        self._send_json(404, {"error": "not found", "path": self.path})
+
+    def do_POST(self):
+        if self.path.startswith("/intelligence/ask/stream"):
+            if not self.headers.get("X-App-Token"):
+                self._send_json(401, {"error": "missing X-App-Token"})
+                return
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            _ = self.rfile.read(length) if length else b""
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+
+            def emit(obj: dict) -> None:
+                self.wfile.write(("data: " + json.dumps(obj) + "\n\n").encode("utf-8"))
+                self.wfile.flush()
+
+            emit({"type": "sources", "sources": [
+                {"repo": "weaviate", "category": "vector_search"},
+                {"repo": "qdrant", "category": "vector_search"},
+                {"repo": "pgvector", "category": "embeddings"},
+            ]})
+            for tok in _CANNED_TOKENS:
+                emit({"type": "token", "text": tok})
+                time.sleep(0.01)
+            emit({"type": "done"})
+            return
+        self._send_json(404, {"error": "not found", "path": self.path})
+
+
+def main() -> None:
+    httpd = ThreadingHTTPServer((HOST, PORT), Handler)
+    print(f"[stub] Reporium local contract stub listening on {HOST}:{PORT}")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/probes/graph_quality.py
+++ b/probes/graph_quality.py
@@ -15,9 +15,14 @@ from datetime import datetime, timezone
 
 import requests
 
-GRAPH_QUALITY_URL = (
-    "https://reporium-api-573778300586.us-central1.run.app/metrics/graph-quality"
-)
+# Default points at the live production API (unchanged behavior). The
+# REPORIUM_API_BASE override lets the local OSS smoke harness (see local/)
+# aim the probe at a contract stub backed by a local Postgres. See
+# local/README.md.
+_API_BASE = os.environ.get(
+    "REPORIUM_API_BASE", "https://reporium-api-573778300586.us-central1.run.app"
+).rstrip("/")
+GRAPH_QUALITY_URL = f"{_API_BASE}/metrics/graph-quality"
 TIMEOUT = 30
 
 

--- a/probes/health.py
+++ b/probes/health.py
@@ -2,13 +2,21 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from datetime import datetime, timezone
 
 import requests
 
-HOME_URL = "https://www.reporium.com/"
-API_HEALTH_URL = "https://reporium-api-573778300586.us-central1.run.app/health"
+# Defaults point at the live production system (unchanged behavior). The
+# REPORIUM_HOME_URL / REPORIUM_API_BASE overrides let the local OSS smoke
+# harness (see local/) aim the probe at a contract stub instead. See
+# local/README.md for the env-pointing rationale.
+HOME_URL = os.environ.get("REPORIUM_HOME_URL", "https://www.reporium.com/")
+_API_BASE = os.environ.get(
+    "REPORIUM_API_BASE", "https://reporium-api-573778300586.us-central1.run.app"
+).rstrip("/")
+API_HEALTH_URL = f"{_API_BASE}/health"
 TIMEOUT = 10
 
 

--- a/probes/synthetic_ask.py
+++ b/probes/synthetic_ask.py
@@ -8,9 +8,17 @@ from datetime import datetime, timezone
 
 import requests
 
-ASK_URL = "https://reporium-api-573778300586.us-central1.run.app/intelligence/ask/stream"
+# Default points at the live production API (unchanged behavior). The
+# REPORIUM_API_BASE override lets the local OSS smoke harness (see local/)
+# aim the probe at a contract stub. See local/README.md.
+_API_BASE = os.environ.get(
+    "REPORIUM_API_BASE", "https://reporium-api-573778300586.us-central1.run.app"
+).rstrip("/")
+ASK_URL = f"{_API_BASE}/intelligence/ask/stream"
 TIMEOUT = 60
-RATE_LIMIT_SLEEP_S = 15
+# Inter-query courtesy sleep against the live API. Overridable (default 15s
+# unchanged) so the local OSS smoke harness can set it to 0. See local/.
+RATE_LIMIT_SLEEP_S = float(os.environ.get("REPORIUM_ASK_SLEEP_S", "15"))
 
 CANARY_QUERIES = [
     "what is a vector database",


### PR DESCRIPTION
## Summary

Adds a free, self-hosted **local dev substrate** under `local/` so the
trust-score computation path can be exercised end to end with **no cloud, no
secrets, and no paid model**. Additive and local-only: nothing here runs in CI,
and the production probes keep their live URLs as defaults.

Refs epic perditioinc/reporium-system-design#5 (Reporium $0 epic), card #6.

## Substrate

A single `docker compose` stack in `local/`:

- **`db`** (`postgres:16-alpine`) seeded from `local/seed/graph_quality.sql`.
- **`stub`** (Python stdlib `http.server` + `psycopg2`) serving the exact
  contracts the three probes read.

## Cloud -> OSS substitution map

| Production dependency | Consumed by | OSS substitute |
| --- | --- | --- |
| `https://www.reporium.com/` home (200) | `probes/health.py` | `stub` `/` -> 200 HTML |
| Cloud Run `reporium-api` `/health` (200) | `probes/health.py` | `stub` `/health` -> 200 JSON |
| `reporium-api` `/intelligence/ask/stream` SSE (LLM-backed, `X-App-Token`) | `probes/synthetic_ask.py` | `stub` deterministic canned `sources` -> `token` -> `done` stream (no paid model) |
| `reporium-api` `/metrics/graph-quality` (Postgres-backed, `X-Admin-Key`) | `probes/graph_quality.py` | `stub` reads edge-family metrics **live from local Postgres**, same `source: "postgres_live"` contract |

The datastore behind graph-quality is a real Postgres container queried over
SQL, so the most data-shaped term of the score runs against an actual DB, not a
hard-coded blob.

## Wiring (minimal, documented, env-pointed)

The three probes gain env-var overrides that **default to the existing
production URLs**, so production behavior is unchanged:

- `REPORIUM_API_BASE` -> `/health`, `/intelligence/ask/stream`, `/metrics/graph-quality`
- `REPORIUM_HOME_URL` -> home-page target
- `REPORIUM_ASK_SLEEP_S` -> inter-query courtesy sleep (default 15s; 0 locally)

`REPORIUM_APP_TOKEN` / `REPORIUM_ADMIN_KEY` already existed; the stub accepts
any non-empty value, so **no real secret is ever needed locally**.

## How to run

```bash
make up      # build + start stub + postgres, wait until healthy
make smoke   # run the 3 probes against the stub + compute a trust score
make down    # stop + remove containers and volumes
```

(Root `Makefile` passes through to `local/Makefile`; targets: `up`, `down`,
`seed`, `smoke`, `logs`, `ps`, `clean`.)

## Validation (docker)

`up --wait` -> `smoke` -> `down -v`, all green:

```
[smoke] PASS composite=97.4
  reliability == 1.0                 -> ok
  quality > 0.0                      -> ok   (0.925 = mean 1.0/0.95/0.9/0.85)
  0 < composite <= 100               -> ok
  graph-quality available            -> ok
  graph-quality source postgres_live -> ok
```

The quality term flows from the seeded Postgres rows through the real
`lib/score.py:quality_subscore`. Existing 14 unit tests still pass.
`smoke.py` writes its snapshot to a temp dir, so it never mutates tracked
`history/`.

## Constraints honored

- **$0 / OSS** only (Postgres + Python stdlib + `psycopg2-binary`).
- **Additive / local only** — no production cloud touched, no CI edits.
- **No secrets** committed or required locally.
- No em/en dashes in new content.

Awaiting human review (reporium = human PR review; not self-merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)