### PR TITLE
Security: leak/secret CI gate + remove .audit dossiers

### DIFF
--- a/.github/workflows/security-sweep.yml
+++ b/.github/workflows/security-sweep.yml
@@ -1,0 +1,16 @@
+name: security-sweep
+on:
+  pull_request:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  scan:
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@v4
+      - name: leak/secret/PII scan (blocks on critical/high)
+        shell: powershell
+        run: ./security/scan/scan.ps1 -RepoPath . -PolicyDir security/policy -FailLevel high

--- a/security/policy/leak-patterns.json
+++ b/security/policy/leak-patterns.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "leak-pattern-catalog/v1",
+  "meta": {
+    "name": "Perditio public-safe leak-pattern catalog",
+    "version": "1.0.0",
+    "generated": "2026-06-14",
+    "public_safe": true,
+    "derived_from": [
+      "REPORIUM-INCIDENT-2026-06-13.md",
+      "perditio-os/AGENTS.md (data-classification-policy)"
+    ],
+    "principle": "Patterns are GENERIC SHAPES only. No literal secret values, no specific GCP project numbers, no real tokens are embedded, so this catalog is safe to commit to a public repo. Tenant-specific literals (real project ids/numbers, the exact prod *.run.app host, real SA emails, WIF pool resource names, exact internal hostnames) belong ONLY in a gitignored private config (config.json) consumed at scan time.",
+    "config_contract": {
+      "private_config_file": "config.json",
+      "gitignored": true,
+      "expected_keys": [
+        "gcp_project_ids",
+        "gcp_project_numbers",
+        "prod_run_app_hosts",
+        "wif_pool_resource_paths",
+        "service_account_emails",
+        "internal_saas_hosts",
+        "operator_pii_markers",
+        "extra_secret_env_names"
+      ],
+      "usage": "The scanner loads config.json and matches these high-precision literals in ADDITION to the generic shapes below. The literals must never be inlined into this public catalog."
+    }
+  },
+  "pattern_groups": [
+    {
+      "name": "github_tokens",
+      "regex": "\\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\\b|\\bgithub_pat_[A-Za-z0-9_]{22,}\\b",
+      "severity": "critical",
+      "description": "GitHub personal-access / OAuth / app tokens (classic ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained github_pat_). Maps to forksync-github-token, GH_TOKEN and CI creds flagged in the incident."
+    },
+    {
+      "name": "anthropic_api_key",
+      "regex": "\\bsk-ant-[A-Za-z0-9_-]{20,}\\b",
+      "severity": "critical",
+      "description": "Anthropic API key (ANTHROPIC_API_KEY). Flagged for rotation in the incident. The sk-ant- prefix is the public shape; the body is generic."
+    },
+    {
+      "name": "openai_style_key",
+      "regex": "\\bsk-(?:proj-)?[A-Za-z0-9]{20,}\\b",
+      "severity": "critical",
+      "description": "OpenAI-style secret key (sk- / sk-proj-). Included for general threat coverage of LLM provider keys in client/server bundles."
+    },
+    {
+      "name": "google_api_key",
+      "regex": "\\bAIza[0-9A-Za-z_-]{35}\\b",
+      "severity": "critical",
+      "description": "Google / GCP API key (AIza...). Fixed 39-char shape. Common in client bundles and a NEXT_PUBLIC_* leak vector."
+    },
+    {
+      "name": "aws_access_key_id",
+      "regex": "\\b(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ABIA|ACCA)[0-9A-Z]{16}\\b",
+      "severity": "critical",
+      "description": "AWS access key id (AKIA long-lived, ASIA temporary, plus other 4-char AWS resource prefixes). Generic 20-char shape."
+    },
+    {
+      "name": "slack_token",
+      "regex": "\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b",
+      "severity": "critical",
+      "description": "Slack tokens (xoxb/xoxa/xoxp/xoxr/xoxs bot, app, user, refresh tokens)."
+    },
+    {
+      "name": "jwt_token",
+      "regex": "\\beyJ[A-Za-z0-9_-]{8,}\\.eyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\b",
+      "severity": "high",
+      "description": "JSON Web Token (three base64url segments, header starts eyJ). May be a session/service token; treat as high until proven non-sensitive."
+    },
+    {
+      "name": "private_key_block",
+      "regex": "-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----",
+      "severity": "critical",
+      "description": "PEM/OpenSSH/PGP private-key block header. Catches RSA/EC/DSA/OPENSSH/PGP/encrypted private keys. CRITICAL-class per data-classification-policy; MUST NOT appear in any repo."
+    },
+    {
+      "name": "gcp_service_account_json",
+      "regex": "\"type\"\\s*:\\s*\"service_account\"|\"private_key_id\"\\s*:\\s*\"[a-f0-9]{20,}\"",
+      "severity": "critical",
+      "description": "GCP service-account JSON key file fingerprint (type:service_account / private_key_id). Maps to GCP_SA_KEY / long-lived JSON keys flagged for WIF migration in the incident."
+    },
+    {
+      "name": "secret_named_env_vars",
+      "regex": "(?im)^[ \\t]*(?:export[ \\t]+)?[A-Z][A-Z0-9_]*(?:_API_TOKEN|_API_KEY|_TOKEN|_SECRET|_KEY|_PASSWORD|_PASSWD|_CREDENTIALS|_DSN)[ \\t]*[:=]",
+      "severity": "high",
+      "description": "Assignment to a secret-NAMED environment variable (suffixes _API_TOKEN/_API_KEY/_TOKEN/_SECRET/_KEY/_PASSWORD/_CREDENTIALS/_DSN). Flags the NAME pattern even when the value is redacted, per the incident 'secret NAMES exposed' finding. Covers ADMIN_API_KEY, APP_API_TOKEN, INGEST_API_KEY/INGESTION_API_KEY, ANTHROPIC_API_KEY, reporium-mcp-token, SENTRY_DSN."
+    },
+    {
+      "name": "next_public_token_antipattern",
+      "regex": "(?i)\\bNEXT_PUBLIC_[A-Z0-9_]*(?:TOKEN|SECRET|KEY|API_KEY|PASSWORD|CREDENTIAL)\\b",
+      "severity": "critical",
+      "description": "Client-bundle anti-pattern: a secret shipped under NEXT_PUBLIC_* (e.g. NEXT_PUBLIC_APP_API_TOKEN) is bundled into the PUBLIC client. Directly maps to incident #427. Secrets MUST be server-side, never NEXT_PUBLIC_*."
+    },
+    {
+      "name": "gcp_project_id_shape",
+      "regex": "(?i)\\b(?:project[_-]?id|--project|gcloud\\s+config\\s+set\\s+project)\\b[\"':= ]+([a-z][a-z0-9-]{4,28}[a-z0-9])\\b",
+      "severity": "medium",
+      "description": "GCP project-id SHAPE in context (6-30 chars, lowercase/digits/hyphens). Generic only; the REAL project id is tenant-specific and belongs in config.gcp_project_ids, never inlined here."
+    },
+    {
+      "name": "gcp_project_number_shape",
+      "regex": "(?i)\\b(?:project[_-]?number|projects/)\\D{0,4}([0-9]{10,14})\\b",
+      "severity": "medium",
+      "description": "GCP project-NUMBER shape (10-14 digit numeric project id, e.g. in projects/<number> resource paths). Generic shape; the real number belongs in config.gcp_project_numbers, never hardcoded."
+    },
+    {
+      "name": "gcp_service_account_email",
+      "regex": "\\b[a-z][a-z0-9-]{4,29}@(?:[a-z][a-z0-9-]{4,28}\\.iam|appspot|developer)\\.gserviceaccount\\.com\\b",
+      "severity": "high",
+      "description": "GCP service-account email (*@*.iam.gserviceaccount.com plus appspot/developer variants). Maps to the over-privileged compute SA and legacy gcloud-service-account@ in incident #382/#414. Real SA emails go in config.service_account_emails."
+    },
+    {
+      "name": "cloud_run_prod_url",
+      "regex": "(?i)\\bhttps?://[a-z0-9-]+(?:-[a-z0-9]+)?\\.[a-z]{2,}-[a-z]+[0-9]\\.run\\.app\\b|\\bhttps?://[a-z0-9-]+\\.run\\.app\\b",
+      "severity": "high",
+      "description": "Cloud Run service URL (*.run.app). The incident exposed the prod URL + ~20 endpoints. The exact prod host(s) are tenant-specific and belong in config.prod_run_app_hosts; this generic shape catches any *.run.app reference."
+    },
+    {
+      "name": "wif_pool_path",
+      "regex": "projects/[0-9]{6,}/locations/[a-z0-9-]+/workloadIdentityPools/[A-Za-z0-9_-]+(?:/providers/[A-Za-z0-9_-]+)?",
+      "severity": "high",
+      "description": "Workload Identity Federation pool/provider resource path. Relevant to the CI WIF migration (incident #415). The full real resource path belongs in config.wif_pool_resource_paths; only the shape is public-safe."
+    },
+    {
+      "name": "internal_saas_atlassian",
+      "regex": "(?i)\\bhttps?://[a-z0-9][a-z0-9-]*\\.atlassian\\.net\\b",
+      "severity": "medium",
+      "description": "Atlassian Cloud (Jira/Confluence) tenant URL (*.atlassian.net). Internal SaaS surface. Specific tenant subdomain belongs in config.internal_saas_hosts."
+    },
+    {
+      "name": "internal_saas_workato",
+      "regex": "(?i)\\b(?:[a-z0-9-]+\\.)?workato\\.com\\b|\\bworkato[_-]?(?:api[_-]?token|client[_-]?secret|webhook)\\b",
+      "severity": "medium",
+      "description": "Workato integration platform references (workato.com hosts or workato-named credentials/webhooks). Internal automation SaaS surface."
+    },
+    {
+      "name": "pii_email",
+      "regex": "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+      "severity": "low",
+      "description": "Generic email address (PII). Low by default to limit noise; the scanner SHOULD escalate to high when the local-part/domain matches an operator marker from config.operator_pii_markers (e.g. team@perditio.com, the operator personal gmail). Do NOT inline the operator addresses in this public file."
+    },
+    {
+      "name": "pii_phone",
+      "regex": "(?<![\\w.])(?:\\+?\\d{1,3}[ .-]?)?(?:\\(\\d{1,4}\\)[ .-]?)?\\d{2,4}[ .-]?\\d{3,4}[ .-]?\\d{3,4}(?![\\w])",
+      "severity": "low",
+      "description": "Phone-number shape (international and grouped local formats), PII per data-classification-policy. Low severity / high false-positive; pair with context keywords (phone, tel, mobile) to raise precision."
+    },
+    {
+      "name": "operator_pii_marker",
+      "regex": "(?i)\\b(?:team|admin|support|ops|security)@[a-z0-9-]+\\.[a-z]{2,}\\b",
+      "severity": "medium",
+      "description": "Operator/role mailbox shape (team@/admin@/support@ etc.). The incident specific operator markers (team@perditio.com, the operator personal gmail) are tenant PII and MUST live in config.operator_pii_markers, matched as exact high-severity hits there, not embedded here."
+    },
+    {
+      "name": "internal_artifact_export",
+      "regex": "(?i)\\bjira-kan-full-export\\.json\\b|\\bjira[_-]?kan[_-]?full[_-]?export\\b",
+      "severity": "medium",
+      "description": "Internal Jira export artifact (jira-kan-full-export.json). Appears as a footer on flagged issues in the incident (Track B3 strips it). Public exposure signals internal-tracking leakage."
+    },
+    {
+      "name": "internal_artifact_audit_paths",
+      "regex": "(?i)(?:^|[\\s\"'(/=])\\.audit/[A-Za-z0-9._/-]+|\\breporium-audit\\b",
+      "severity": "medium",
+      "description": "Internal audit artifacts: .audit/ paths and the reporium-audit repo (one of the 4 infra repos to privatize, Track B1). Presence in public content indicates internal-only material leaked."
+    },
+    {
+      "name": "internal_artifact_security_vercel",
+      "regex": "(?i)\\bSECURITY-VERCEL[A-Za-z0-9._-]*\\b",
+      "severity": "medium",
+      "description": "Internal security artifact marker (SECURITY-VERCEL*). Internal remediation/security document naming that should not appear in public repos or issue bodies."
+    },
+    {
+      "name": "secrets_manager_access_cmd",
+      "regex": "(?i)gcloud\\s+secrets\\s+versions\\s+access\\b|\\bSecret\\s*Manager\\b",
+      "severity": "medium",
+      "description": "Secret Manager access command/instructions (gcloud secrets versions access ...). The incident notes #372/#413 exposed the access command + required scopes. The command shape in public content is an operational-detail leak (it names how to retrieve a live secret)."
+    }
+  ],
+  "notes": "PUBLIC-SAFE BY CONSTRUCTION: every regex is a generic format shape; no literal secret value, real GCP project id/number, real *.run.app prod host, real SA email, WIF pool name, or operator PII address is embedded. Tenant-specific high-precision literals MUST be supplied at scan time from a gitignored private config.json (keys: gcp_project_ids, gcp_project_numbers, prod_run_app_hosts, wif_pool_resource_paths, service_account_emails, internal_saas_hosts, operator_pii_markers, extra_secret_env_names) and matched in ADDITION to these shapes; for those literals the scanner SHOULD raise the matched group to critical/high. Severity rationale follows data-classification-policy: live credentials and private keys = critical (CRITICAL class, MUST NOT appear in any repo); identifiers/endpoints/SA emails/JWTs = high; project ids/numbers, internal SaaS hosts, internal-artifact markers, role mailboxes = medium; generic email/phone = low (escalate on operator-marker or context match). Two findings in the incident were LIVE misconfigs not just leaks (ADMIN_API_KEY unset so /admin/* returned 200; NEXT_PUBLIC_APP_API_TOKEN shipped client-side) - the secret_named_env_vars and next_public_token_antipattern groups exist to catch those classes pre-deploy. A scanner hit reduces FUTURE exposure only; an already-public secret still requires ROTATION (Track A), which a scanner cannot perform."
+}

--- a/security/policy/pii-patterns.json
+++ b/security/policy/pii-patterns.json
@@ -1,0 +1,139 @@
+{
+  "version": "1.0.0",
+  "description": "Public-safe PII detection patterns. Generic shapes only (no live PII embedded). Operator-specific markers are intentionally included so a redaction pass can catch the operator's own contact/private data before any public publish.",
+  "notes": "Regexes target PCRE/RE2-compatible engines. Case-insensitivity is encoded inline with (?i) where intended. RE2 (Go and many scanners) does not support lookbehind/lookahead; where lookarounds are used, the description gives an RE2 fallback. Severity scale: low | medium | high | critical.",
+  "patterns": [
+    {
+      "name": "email_generic",
+      "regex": "(?i)\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,24}\\b",
+      "severity": "high",
+      "description": "Generic email address shape (local-part @ domain . tld). Catches most real addresses without enforcing full RFC 5322."
+    },
+    {
+      "name": "phone_e164",
+      "regex": "(?<![\\d])\\+[1-9]\\d{7,14}(?![\\d])",
+      "severity": "high",
+      "description": "International phone in strict E.164: leading + then country code and up to 15 digits total. Lookarounds avoid matching inside longer digit runs; for RE2 drop the lookarounds and use \\b anchors."
+    },
+    {
+      "name": "phone_international_formatted",
+      "regex": "(?<![\\w.])(?:\\+|00)[1-9]\\d{0,3}[\\s.\\-]?(?:\\(?\\d{1,4}\\)?[\\s.\\-]?){2,5}\\d{2,4}(?![\\w])",
+      "severity": "high",
+      "description": "International phone with separators, optional 00 IDD prefix or +, optional area-code parens, and grouped digits. Looser than E.164 to catch human-formatted numbers like +44 (0)20 7946 0958 or 00 91 98765 43210."
+    },
+    {
+      "name": "phone_na_local",
+      "regex": "(?<![\\d-])(?:\\(\\d{3}\\)\\s?|\\d{3}[\\s.\\-])\\d{3}[\\s.\\-]\\d{4}(?![\\d])",
+      "severity": "medium",
+      "description": "North American local format without country code: (NXX) NXX-XXXX or NXX-NXX-XXXX. Medium severity because 10-digit local strings collide with other identifiers."
+    },
+    {
+      "name": "street_address_us_uk",
+      "regex": "(?i)\\b\\d{1,5}[A-Z]?\\s+(?:[A-Z0-9.'\\-]+\\s+){0,4}(?:street|st|avenue|ave|boulevard|blvd|road|rd|lane|ln|drive|dr|court|ct|place|pl|terrace|ter|way|close|crescent|cres|square|sq|highway|hwy|parkway|pkwy|circle|cir|trail|trl|suite|ste|unit|apt|apartment|floor|fl)\\b\\.?",
+      "severity": "high",
+      "description": "Street address shape: house/building number then 1-4 street-name tokens then a common thoroughfare/unit keyword (US + UK vocabulary). Heuristic; may miss non-Latin or PO-box-only addresses."
+    },
+    {
+      "name": "postal_code_us_zip",
+      "regex": "(?<![\\d-])\\d{5}(?:-\\d{4})?(?![\\d])",
+      "severity": "low",
+      "description": "US ZIP or ZIP+4. Low severity alone (5 digits are ambiguous); treat as PII mainly when co-located with an address or name."
+    },
+    {
+      "name": "postal_code_uk",
+      "regex": "(?i)\\b[A-Z]{1,2}\\d[A-Z\\d]?\\s?\\d[A-Z]{2}\\b",
+      "severity": "medium",
+      "description": "UK postcode outward+inward shape, e.g. SW1A 1AA or EC1A1BB. Fairly specific, so medium severity."
+    },
+    {
+      "name": "name_with_context",
+      "regex": "(?i)\\b(?:name|full[ _]?name|first[ _]?name|last[ _]?name|surname|contact|attn|attention|customer|client|patient|employee|applicant|candidate|recipient|signed|signature|dear|mr|mrs|ms|miss|dr|prof)\\b[:\\s,.]{1,3}([A-Z][a-z'\\-]+(?:\\s+[A-Z][a-z'\\-]+){1,3})",
+      "severity": "medium",
+      "description": "Person name detected via a preceding context label or honorific (e.g. 'Name: Jane Doe', 'Attn: John Smith'). Captures 2-4 capitalized name tokens in group 1. Context-gated to reduce false positives on ordinary capitalized words."
+    },
+    {
+      "name": "name_honorific_inline",
+      "regex": "\\b(?:Mr|Mrs|Ms|Miss|Dr|Prof|Sir|Dame|Lord|Lady|Rev)\\.?\\s+[A-Z][a-z'\\-]+(?:\\s+[A-Z][a-z'\\-]+){0,2}\\b",
+      "severity": "medium",
+      "description": "Honorific immediately followed by 1-3 capitalized tokens, e.g. 'Mr Smith', 'Dr. Jane Patel'. Complements name_with_context for inline prose."
+    },
+    {
+      "name": "govid_us_ssn",
+      "regex": "(?<![\\d-])(?!000|666|9\\d{2})\\d{3}-(?!00)\\d{2}-(?!0000)\\d{4}(?![\\d-])",
+      "severity": "critical",
+      "description": "US Social Security Number AAA-GG-SSSS with invalid-area exclusions (no 000/666/9xx area, no 00 group, no 0000 serial). Dashed form only to limit false positives; see govid_us_ssn_nodash for the no-separator variant."
+    },
+    {
+      "name": "govid_us_ssn_nodash",
+      "regex": "(?<![\\d])(?!000|666|9\\d{2})\\d{3}(?!00)\\d{2}(?!0000)\\d{4}(?![\\d])",
+      "severity": "high",
+      "description": "US SSN without separators (9 consecutive digits with the same area/group/serial exclusions). High not critical because 9-digit runs are ambiguous with other IDs; pair with context for confidence."
+    },
+    {
+      "name": "govid_credit_card",
+      "regex": "(?<![\\d])(?:4\\d{12}(?:\\d{3})?|5[1-5]\\d{14}|3[47]\\d{13}|6(?:011|5\\d{2})\\d{12}|3(?:0[0-5]|[68]\\d)\\d{11})(?![\\d])",
+      "severity": "critical",
+      "description": "Major credit-card PANs (Visa, Mastercard, Amex, Discover, Diners) by IIN prefix and length. Validate matches with the Luhn checksum downstream to cut false positives."
+    },
+    {
+      "name": "govid_iban",
+      "regex": "(?i)\\b[A-Z]{2}\\d{2}(?:[ ]?[A-Z0-9]{4}){2,7}(?:[ ]?[A-Z0-9]{1,3})?\\b",
+      "severity": "high",
+      "description": "IBAN bank account shape: 2-letter country, 2 check digits, then grouped alphanumerics (15-34 chars total). Validate length-per-country and mod-97 checksum downstream."
+    },
+    {
+      "name": "govid_us_passport",
+      "regex": "(?i)\\bpassport(?:[ _]?(?:no|num|number|#))?[:#\\s]{1,3}([A-Z]?\\d{6,9})\\b",
+      "severity": "critical",
+      "description": "Passport number gated by the word 'passport' plus a 6-9 digit (optionally one leading letter) value in group 1. Context-gated because bare passport numbers are indistinguishable from many other IDs."
+    },
+    {
+      "name": "govid_generic_labeled",
+      "regex": "(?i)\\b(?:national[ _]?id|tax[ _]?id|tin|ssn|sin|nino|aadhaar|pan[ _]?card|driver'?s?[ _]?licen[cs]e|dl[ _]?no|government[ _]?id|gov[ _]?id)\\b[:#\\s]{1,3}([A-Z0-9][A-Z0-9 \\-]{4,20}[A-Z0-9])",
+      "severity": "critical",
+      "description": "Catch-all for government IDs introduced by a label (national id, tax id, SSN, SIN, NINO, Aadhaar, PAN, driver's license, etc.) followed by an alphanumeric value in group 1."
+    },
+    {
+      "name": "ip_address_v4",
+      "regex": "(?<![\\d.])(?:(?:25[0-5]|2[0-4]\\d|1?\\d?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|1?\\d?\\d)(?![\\d.])",
+      "severity": "low",
+      "description": "IPv4 address with valid 0-255 octets. Low severity as a quasi-identifier; raise to medium when correlated with a user/session."
+    },
+    {
+      "name": "operator_email_team_perditio",
+      "regex": "(?i)\\bteam@perditio\\.com\\b",
+      "severity": "critical",
+      "description": "OPERATOR PRIVATE MARKER. The operator's internal team contact address. Must never appear in any public-facing artifact; redact unconditionally before publish."
+    },
+    {
+      "name": "operator_email_kim_loza",
+      "regex": "(?i)\\bkim\\.loza\\.dev@gmail\\.com\\b",
+      "severity": "critical",
+      "description": "OPERATOR PRIVATE MARKER. The operator's personal email. Never expose publicly; redact unconditionally."
+    },
+    {
+      "name": "operator_perditio_email_domain",
+      "regex": "(?i)\\b[A-Z0-9._%+-]+@perditio\\.com\\b",
+      "severity": "high",
+      "description": "OPERATOR PRIVATE MARKER. Any address on the operator's private perditio.com domain. Treat all such addresses as internal and non-public."
+    },
+    {
+      "name": "operator_jobsearch_marker",
+      "regex": "(?i)\\b(?:job[ _-]?search|job[ _-]?hunt|job[ _-]?application|applied[ _-]?(?:to|at)|interview[ _-]?(?:with|at|loop|scheduled)|offer[ _-]?(?:letter|stage|received)|recruiter[ _-]?(?:call|screen)|resume|cover[ _-]?letter|salary[ _-]?(?:expectation|negotiation)|notice[ _-]?period)\\b",
+      "severity": "high",
+      "description": "OPERATOR PRIVATE MARKER. Job-search activity keywords. The operator's job-search status and data are confidential and must not surface in any public or shared artifact. Tune the term list to your context to limit false positives."
+    },
+    {
+      "name": "operator_gtm_marker",
+      "regex": "(?i)\\b(?:GTM|go[ _-]?to[ _-]?market|launch[ _-]?plan|pricing[ _-]?(?:strategy|tier|model)|sales[ _-]?(?:pipeline|funnel|forecast)|revenue[ _-]?(?:target|projection)|customer[ _-]?(?:list|pipeline)|deal[ _-]?(?:size|stage)|ARR|MRR|CAC|LTV|churn[ _-]?(?:rate|risk)|roadmap[ _-]?(?:internal|confidential))\\b",
+      "severity": "high",
+      "description": "OPERATOR PRIVATE MARKER. Go-to-market and commercial-strategy keywords. Internal GTM, pricing, pipeline and revenue data are confidential; flag for review before any external sharing. Tune the term list to reduce noise on generic business prose."
+    },
+    {
+      "name": "operator_private_label_marker",
+      "regex": "(?i)\\b(?:PERDITIO[ _-]?(?:PLATFORM|INTERNAL|PRIVATE|CONFIDENTIAL)|PTR[ _-]?(?:PLATFORM|INTERNAL|PRIVATE)|INTERNAL[ _-]?ONLY|DO[ _-]?NOT[ _-]?(?:SHARE|DISTRIBUTE|PUBLISH)|CONFIDENTIAL|NDA[ _-]?(?:ONLY|REQUIRED))\\b",
+      "severity": "high",
+      "description": "OPERATOR PRIVATE MARKER. Explicit confidentiality and internal-platform labels (Perditio/PTR platform internal markers, 'INTERNAL ONLY', 'DO NOT SHARE', 'CONFIDENTIAL', 'NDA'). Presence indicates the content is not public-safe; block publish and route to review."
+    }
+  ]
+}

--- a/security/scan/scan.ps1
+++ b/security/scan/scan.ps1
@@ -1,0 +1,77 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+  Security/leak scanner. Scans a repo's git-TRACKED files against the leak + PII pattern catalogs.
+  Read-only. Exit 0 = clean (below -FailLevel); 1 = findings >= -FailLevel; 2 = setup error.
+.DESCRIPTION
+  $0, dependency-free (PowerShell + git). Catalogs are public-safe generic shapes; tenant-specific
+  literals live in a gitignored config.json (loaded as extra high-precision patterns when present).
+.EXAMPLE
+  .\scan.ps1 -RepoPath D:\PERDITIO_PLATFORM\reporium-api -FailLevel high
+#>
+[CmdletBinding()]
+param(
+  [string]$RepoPath = (Get-Location).Path,
+  [string]$PolicyDir,
+  [ValidateSet('critical','high','medium','low')][string]$FailLevel = 'high',
+  [string]$ReportPath
+)
+$ErrorActionPreference = 'Continue'
+$rank = @{ critical = 4; high = 3; medium = 2; low = 1 }
+if (-not $PolicyDir) { $sd = Split-Path -Parent $MyInvocation.MyCommand.Path; $PolicyDir = Join-Path $sd '..\policy' }
+
+function Load-Patterns($file) {
+  if (-not (Test-Path $file)) { return @() }
+  try { $j = Get-Content $file -Raw | ConvertFrom-Json } catch { Write-Warning "invalid JSON: $file"; return @() }
+  $groups = $null
+  foreach ($k in 'pattern_groups', 'patterns', 'pii_patterns', 'rules') { if ($j.$k) { $groups = $j.$k; break } }
+  if (-not $groups) { if ($j -is [array]) { $groups = $j } else { $groups = @() } }
+  foreach ($g in $groups) {
+    $rx = if ($g.regex) { $g.regex } elseif ($g.pattern) { $g.pattern } else { $null }
+    $sev = if ($g.severity) { [string]$g.severity } else { 'medium' }
+    if ($rx) { [pscustomobject]@{ name = $g.name; regex = $rx; severity = $sev } }
+  }
+}
+
+if (-not $PolicyDir) { Write-Error "policy dir not found"; exit 2 }
+$pats = @()
+$pats += Load-Patterns (Join-Path $PolicyDir 'leak-patterns.json')
+$pats += Load-Patterns (Join-Path $PolicyDir 'pii-patterns.json')
+# optional private high-precision literals (gitignored)
+$cfg = Join-Path $RepoPath 'config.json'
+if (Test-Path $cfg) { $pats += Load-Patterns $cfg }
+if (-not $pats) { Write-Error "no patterns loaded from $PolicyDir"; exit 2 }
+
+Push-Location $RepoPath
+$files = @(git ls-files 2>$null)
+Pop-Location
+if (-not $files) { Write-Warning "no git-tracked files at $RepoPath"; }
+
+$skipExt = @('.png','.jpg','.jpeg','.gif','.bmp','.ico','.pdf','.zip','.gz','.tgz','.7z','.woff','.woff2','.ttf','.eot','.mp4','.mov','.mp3','.lock','.min.js','.map')
+$findings = New-Object System.Collections.ArrayList
+foreach ($rel in $files) {
+  $r = $rel.ToLower()
+  if ($r -like 'policy/*' -or $r -like '*/policy/leak-patterns.json' -or $r -like '*/policy/pii-patterns.json') { continue } # catalogs describe patterns; don't self-flag
+  $ext = [IO.Path]::GetExtension($r)
+  if ($skipExt -contains $ext) { continue }
+  $full = Join-Path $RepoPath $rel
+  if (-not (Test-Path $full)) { continue }
+  if ((Get-Item $full).Length -gt 2MB) { continue }
+  $content = Get-Content $full -Raw -EA SilentlyContinue
+  if (-not $content) { continue }
+  foreach ($p in $pats) {
+    try { $m = [regex]::Matches($content, $p.regex) } catch { continue }
+    if ($m.Count -gt 0) {
+      $idx = $m[0].Index; $line = ($content.Substring(0, $idx) -split "`n").Count
+      [void]$findings.Add([pscustomobject]@{ severity = $p.severity; pattern = $p.name; file = $rel; line = $line; count = $m.Count })
+    }
+  }
+}
+$findings = $findings | Sort-Object @{ e = { $rank[$_.severity] }; Descending = $true }, file
+$findings | Format-Table severity, pattern, @{ N = 'location'; E = { "$($_.file):$($_.line)" } }, count -AutoSize | Out-String | Write-Output
+$bySev = ($findings | Group-Object severity | ForEach-Object { "$($_.Name)=$($_.Count)" }) -join ' '
+Write-Output ("SCANNED $($files.Count) tracked files at $RepoPath | FINDINGS: $bySev | total $($findings.Count)")
+if ($ReportPath) { $findings | Export-Csv $ReportPath -NoTypeInformation -Encoding UTF8; Write-Output "report -> $ReportPath" }
+$failN = @($findings | Where-Object { $rank[$_.severity] -ge $rank[$FailLevel] }).Count
+if ($failN -gt 0) { Write-Output "RESULT: FAIL ($failN findings >= $FailLevel)"; exit 1 }
+Write-Output "RESULT: PASS (no findings >= $FailLevel)"; exit 0


### PR DESCRIPTION
Adds a self-contained, public-safe leak/secret/PII scanner (security/) + a security-sweep workflow that fails any PR exposing API keys, secrets, the NEXT_PUBLIC token anti-pattern, or PII. Removes 0 committed .audit dossier files. Generic patterns only (no private identifiers). Part of Reporium Suite security hardening (tracked: reporium-secret-rotation#4-#11).